### PR TITLE
Correct 2x3 male, 2x5 female; add resistor part#; add links to all parts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ provides 12 ii headers and additional pull-up to support larger ii networks.
 
 see http://digikey.com
 
-* (1) header, female, 2x3 S7071-ND
-* (12) header, male, 2x4 609-3218-ND 
-* (1) 3v3 reg AZ1117CH-3.3TRG1DICT-ND
-* (1) header, male, 2x5 S6105-ND 
-* (2) resistor 1206 2.2k
-* (1) header, male, shrouded, 2x5 ED1543-ND 
+* (1) header, female, 2x3 [S7071-ND](https://www.digikey.com/products/en?keywords=S7071-ND)
+* (12) header, male, 2x3 [609-3218-ND](https://www.digikey.com/products/en?keywords=609-3218-ND)
+* (1) 3v3 reg [AZ1117CH-3.3TRG1DICT-ND](https://www.digikey.com/products/en?keywords=Z1117CH-3.3TRG1DICT-ND)
+* (1) header, female, 2x5 [S6105-ND](https://www.digikey.com/products/en?keywords=S6105-ND)
+* (2) resistor 1206 2.2k [P2.20KFCT-ND](https://www.digikey.com/products/en?keywords=P2.20KFCT-ND)
+* (1) header, male, shrouded, 2x5 [ED1543-ND](https://www.digikey.com/products/en?keywords=ED1543-ND)
 
 pcb via oshpark: https://oshpark.com/shared_projects/kg4mZSCg 
 


### PR DESCRIPTION
I was reading through the readme this morning and momentarily confused by the male 2x3 headers being listed as 2x4 and the female 2x5 being listed as male. I figured a lot of folks coming to this project will be fairly inexperienced (I'm inexperienced myself) and might benefit from the correction.

I also added a part for the resistor (~140K currently ready to ship, so probably a safe bet) and direct links to each part in the form of a search, so in the event the part is discontinued I am hoping Digikey will be smart enough to show alternatives instead of taking the user directly to the part.

Thanks for everything! 
Best,
Tim (xenus_dad@llllllll)